### PR TITLE
feat: implement OpenTelemetry traces hook

### DIFF
--- a/openfeature/contrib/hooks/README.md
+++ b/openfeature/contrib/hooks/README.md
@@ -1,7 +1,7 @@
 # OpenFeature Python Hooks
 Hooks are a mechanism whereby application developers can add arbitrary behavior to flag evaluation.
 They operate similarly to middleware in many web frameworks. Please see the
-[spec]("https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md") for more details.
+[spec](https://openfeature.dev/specification/sections/hooks) for more details.
 
 ## OpenTelemetry Hook
 

--- a/openfeature/contrib/hooks/README.md
+++ b/openfeature/contrib/hooks/README.md
@@ -1,4 +1,37 @@
 # OpenFeature Python Hooks
-Hooks are a mechanism whereby application developers can add arbitrary behavior to flag evaluation. 
-They operate similarly to middleware in many web frameworks. Please see the 
+Hooks are a mechanism whereby application developers can add arbitrary behavior to flag evaluation.
+They operate similarly to middleware in many web frameworks. Please see the
 [spec]("https://github.com/open-feature/spec/blob/main/specification/sections/04-hooks.md") for more details.
+
+## OpenTelemetry Hook
+
+The OpenTelemetry tracing hook for OpenFeature provides a [spec compliant][otel-spec] way to automatically add a feature flag evaluation to a span as a span event. Since feature flags are dynamic and affect runtime behavior, it’s important to collect relevant feature flag telemetry signals. This can be used to determine the impact a feature has on a request, enabling enhanced observability use cases, such as A/B testing or progressive feature releases.
+
+### Usage
+
+OpenFeature provides various ways to register hooks. The location that a hook is registered affects when the hook is run. It's recommended to register the `TracingHook` globally in most situations but it's possible to only enable the hook on specific clients. You should **never** register the `TracingHook` globally and on a client.
+
+More information on hooks can be found in the [OpenFeature documentation][hook-concept].
+
+#### Register Globally
+
+The `TracingHook` can be set on the OpenFeature singleton. This will ensure that every flag evaluation will always create a span event, if am active span is available.
+
+```python
+from openfeature import api
+from openfeature.contrib.hooks.otel import TracingHook
+
+api.add_hooks(TracingHook())
+```
+
+#### Register Per Client
+
+The `TracingHook` can be set on an individual client. This should only be done if it wasn't set globally and other clients shouldn't use this hook. Setting the hook on the client will ensure that every flag evaluation performed by this client will always create a span event, if an active span is available.
+
+```python
+from openfeature import api
+from openfeature.contrib.hooks.otel import TracingHook
+
+client = api.get_client("my-app")
+client.add_hooks(TracingHook())
+```

--- a/openfeature/contrib/hooks/otel.py
+++ b/openfeature/contrib/hooks/otel.py
@@ -14,7 +14,7 @@ class EventAttributes:
     PROVIDER_NAME = f"{OTEL_EVENT_NAME}.provider_name"
 
 
-class OTelTracesHook(Hook):
+class TracingHook(Hook):
     def after(
         self, hook_context: HookContext, details: FlagEvaluationDetails, hints: dict
     ):

--- a/openfeature/contrib/hooks/otel.py
+++ b/openfeature/contrib/hooks/otel.py
@@ -1,0 +1,44 @@
+import json
+
+from openfeature.flag_evaluation import FlagEvaluationDetails
+from openfeature.hook import Hook, HookContext
+from opentelemetry import trace
+
+
+OTEL_EVENT_NAME = "feature_flag"
+
+
+class EventAttributes:
+    FLAG_KEY = f"{OTEL_EVENT_NAME}.key"
+    FLAG_VARIANT = f"{OTEL_EVENT_NAME}.variant"
+    PROVIDER_NAME = f"{OTEL_EVENT_NAME}.provider_name"
+
+
+class OTelTracesHook(Hook):
+    def after(
+        self, hook_context: HookContext, details: FlagEvaluationDetails, hints: dict
+    ):
+        current_span = trace.get_current_span()
+
+        variant = details.variant
+        if variant is None:
+            if isinstance(details.value, str):
+                variant = str(details.value)
+            else:
+                variant = json.dumps(details.value)
+
+        event_attributes = {
+            EventAttributes.FLAG_KEY: details.flag_key,
+            EventAttributes.FLAG_VARIANT: variant,
+        }
+
+        if hook_context.provider_metadata:
+            event_attributes[
+                EventAttributes.PROVIDER_NAME
+            ] = hook_context.provider_metadata.name
+
+        current_span.add_event(OTEL_EVENT_NAME, event_attributes)
+
+    def error(self, hook_context: HookContext, exception: Exception, hints: dict):
+        current_span = trace.get_current_span()
+        current_span.record_exception(exception)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,3 +8,4 @@ flake8
 pytest-mock
 coverage
 openfeature-sdk
+opentelemetry-api

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,8 @@ click==8.1.3
     #   pip-tools
 coverage==7.2.7
     # via -r requirements-dev.in
+deprecated==1.2.14
+    # via opentelemetry-api
 dill==0.3.4
     # via pylint
 distlib==0.3.4
@@ -28,6 +30,8 @@ flake8==4.0.1
     # via -r requirements-dev.in
 identify==2.5.0
     # via pre-commit
+importlib-metadata==6.8.0
+    # via opentelemetry-api
 iniconfig==1.1.1
     # via pytest
 isort==5.10.1
@@ -43,6 +47,8 @@ mypy-extensions==0.4.3
 nodeenv==1.6.0
     # via pre-commit
 openfeature-sdk==0.3.1
+    # via -r requirements-dev.in
+opentelemetry-api==1.19.0
     # via -r requirements-dev.in
 packaging==21.3
     # via pytest
@@ -92,7 +98,11 @@ virtualenv==20.14.1
 wheel==0.37.1
     # via pip-tools
 wrapt==1.14.1
-    # via astroid
+    # via
+    #   astroid
+    #   deprecated
+zipp==3.16.2
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tests/hooks/test_otel.py
+++ b/tests/hooks/test_otel.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock
+
+import pytest
+from openfeature.contrib.hooks.otel import OTelTracesHook
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.flag_evaluation import FlagEvaluationDetails, FlagType
+from openfeature.hook import HookContext
+from opentelemetry import trace
+from opentelemetry.trace import Span
+
+
+@pytest.fixture
+def mock_get_current_span(monkeypatch):
+    monkeypatch.setattr(trace, "get_current_span", Mock())
+
+
+def test_before(mock_get_current_span):
+    # Given
+    hook = OTelTracesHook()
+    hook_context = HookContext(
+        flag_key="flag_key",
+        flag_type=FlagType.BOOLEAN,
+        default_value=False,
+        evaluation_context=EvaluationContext(),
+    )
+    details = FlagEvaluationDetails(
+        flag_key="flag_key",
+        value=True,
+        variant="enabled",
+        reason=None,
+        error_code=None,
+        error_message=None,
+    )
+
+    mock_span = Mock(spec=Span)
+    trace.get_current_span.return_value = mock_span
+
+    # When
+    hook.after(hook_context, details, hints={})
+
+    # Then
+    mock_span.add_event.assert_called_once_with(
+        "feature_flag",
+        {
+            "feature_flag.key": "flag_key",
+            "feature_flag.variant": "enabled",
+        },
+    )
+
+
+def test_error(mock_get_current_span):
+    # Given
+    hook = OTelTracesHook()
+    hook_context = HookContext(
+        flag_key="flag_key",
+        flag_type=FlagType.BOOLEAN,
+        default_value=False,
+        evaluation_context=EvaluationContext(),
+    )
+    exception = Exception()
+
+    mock_span = Mock(spec=Span)
+    trace.get_current_span.return_value = mock_span
+
+    # When
+    hook.error(hook_context, exception, hints={})
+
+    # Then
+    mock_span.record_exception.assert_called_once_with(exception)

--- a/tests/hooks/test_otel.py
+++ b/tests/hooks/test_otel.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
-from openfeature.contrib.hooks.otel import OTelTracesHook
+from openfeature.contrib.hooks.otel import TracingHook
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.flag_evaluation import FlagEvaluationDetails, FlagType
 from openfeature.hook import HookContext
@@ -16,7 +16,7 @@ def mock_get_current_span(monkeypatch):
 
 def test_before(mock_get_current_span):
     # Given
-    hook = OTelTracesHook()
+    hook = TracingHook()
     hook_context = HookContext(
         flag_key="flag_key",
         flag_type=FlagType.BOOLEAN,
@@ -50,7 +50,7 @@ def test_before(mock_get_current_span):
 
 def test_error(mock_get_current_span):
     # Given
-    hook = OTelTracesHook()
+    hook = TracingHook()
     hook_context = HookContext(
         flag_key="flag_key",
         flag_type=FlagType.BOOLEAN,


### PR DESCRIPTION
## This PR

- Implements an OpenTelemetry tracing hook according to the semantic conventions for feature flags.

### Related Issues

Implements [#7](https://github.com/open-feature/python-sdk-contrib/issues/7)
