### PR TITLE
fix: remove setup from flagd tests

### DIFF
--- a/providers/openfeature-provider-flagd/tests/test_flagd.py
+++ b/providers/openfeature-provider-flagd/tests/test_flagd.py
@@ -1,14 +1,5 @@
 from numbers import Number
 
-from openfeature import api
-from openfeature.contrib.provider.flagd import FlagdProvider
-
-
-def setup():
-    api.set_provider(FlagdProvider())
-    provider = api.get_provider()
-    assert isinstance(provider, FlagdProvider)
-
 
 def test_should_get_boolean_flag_from_flagd(flagd_provider_client):
     # Given


### PR DESCRIPTION

## This PR

Removes the `setup` function from Flagd tests which was not testing anything useful and was calling the undocumented `get_provider` function. `get_provider` was removed from the SDK API in the latest version.
