### PR TITLE
ci: add pr trigger types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,11 @@
 name: "Build, lint, and test"
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     branches:
       - main
 


### PR DESCRIPTION
## This PR

- adds pr trigger types
- removes changes to main trigger

### Notes

This should trigger a CI run for a release PR.

https://github.com/open-feature/python-sdk-contrib/pull/40
