### PR TITLE
ci: add generated protobuf files to sdist and wheel

### DIFF
--- a/providers/openfeature-provider-flagd/pyproject.toml
+++ b/providers/openfeature-provider-flagd/pyproject.toml
@@ -1,6 +1,6 @@
 # pyproject.toml
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-build-scripts"]
 build-backend = "hatchling.build"
 
 [project]
@@ -49,10 +49,22 @@ cov = [
 ]
 
 [tool.hatch.build.targets.sdist]
+ignore-vcs = true
 exclude = [
   ".gitignore",
   "schemas",
 ]
 
+[[tool.hatch.build.hooks.build-scripts.scripts]]
+commands = [
+  "./scripts/gen_protos.sh",
+]
+artifacts = [
+  "",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/openfeature"]
+artifacts = [
+  "src/openfeature/contrib/provider/flagd/proto/**/*.py",
+]

--- a/providers/openfeature-provider-flagd/scripts/gen_protos.sh
+++ b/providers/openfeature-provider-flagd/scripts/gen_protos.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-buf generate buf.build/open-feature/flagd --template schemas/protobuf/buf.gen.python.yaml --output schemas
-rm -rf openfeature/contrib/provider/flagd/proto
+buf generate buf.build/open-feature/flagd --template ../../schemas/protobuf/buf.gen.python.yaml --output schemas
+rm -rf src/openfeature/contrib/provider/flagd/proto
 sed -i.bak 's/^from schema.v1 import/from . import/' proto/python/schema/v1/*.py
 rm proto/python/schema/v1/*.bak
 mv proto/python src/openfeature/contrib/provider/flagd/proto


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- leveraged `hatch-build-scripts` plugin to run the `gen_protos.sh`
- fixed the `gen_protos.sh` file to correctly the paths
- had to add `ignore-vcs = true` to make it all work, otherwise `hatch` just ignored the generated files

