### PR TITLE
feat: replace scheme with tls argument in FlagdProvider constructor

### DIFF
--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/defaults.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/defaults.py
@@ -1,5 +1,5 @@
 class Defaults:
     HOST = "localhost"
     PORT = 8013
-    SCHEMA = "http"
+    TLS = False
     TIMEOUT = 2  # seconds

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/provider.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/provider.py
@@ -54,28 +54,26 @@ class FlagdProvider(AbstractProvider):
 
     def __init__(
         self,
-        schema: str = Defaults.SCHEMA,
         host: str = Defaults.HOST,
         port: int = Defaults.PORT,
+        tls: bool = Defaults.TLS,
         timeout: int = Defaults.TIMEOUT,
     ):
         """
         Create an instance of the FlagdProvider
 
-        :param schema: the schema for the transport protocol, e.g. 'http', 'https'
         :param host: the host to make requests to
         :param port: the port the flagd service is available on
+        :param tls: enable/disable secure TLS connectivity
         :param timeout: the maximum to wait before a request times out
         """
-        self.schema = schema
         self.host = host
         self.port = port
+        self.tls = tls
         self.timeout = timeout
 
-        channel_factory = (
-            grpc.insecure_channel if schema == "http" else grpc.secure_channel
-        )
-        self.channel = channel_factory(f"{self.host}:{self.port}")
+        channel_factory = grpc.secure_channel if tls else grpc.insecure_channel
+        self.channel = channel_factory(f"{host}:{port}")
         self.stub = schema_pb2_grpc.ServiceStub(self.channel)
 
     def shutdown(self):


### PR DESCRIPTION
Replace `schema` parameter which was a leftover from the previous HTTP-based implementation.

The `tls` parameter now matches what the rest of the provider implementations are using, and maps better to the standard `FLAGD_TLS` environment variable (not implemented yet).

Note: this is technically a breaking change, but I'd venture that no users would currently be affected.