### PR TITLE
docs: remove experimental badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # OpenFeature Python Contributions
 
-![Experimental](https://img.shields.io/badge/experimental-breaking%20changes%20allowed-yellow)
-![Alpha](https://img.shields.io/badge/alpha-release-red)
-
-> ⚠️ This repository is a work-in-progress. Tooling and documentation may be incomplete. ⚠️
-> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The Python SDK is under active development and is subject to change.
-
 This repository is intended for OpenFeature contributions which are not included in the [OpenFeature SDK](https://github.com/open-feature/python-sdk).
 
 The project includes:


### PR DESCRIPTION
## This PR

- removes experimental badge from the readme

### Notes

The Python SDK is at a place where we can build sharable providers and hooks. Removing the label because each artifact is following semantic convention.
