### PR TITLE
build(renovate): Utilize default OpenFeature Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
-  "semanticCommits": "enabled",
+  "extends": ["github>open-feature/community-tooling"],
   "pep621": {
     "enabled": true
   },
   "pre-commit": {
     "enabled": true
-  },
-  "packageRules": [
-    {
-      "description": "Automerge non-major updates",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "automerge": true
-    }
-  ]
+  }
 }


### PR DESCRIPTION
We do have a default OpenFeature Renovate configuration within our community-tooling repository. (https://github.com/open-feature/community-tooling/blob/main/renovate.json)

To reduce maintenance efforts, we should stick to the general one as a basis.
