### PR TITLE
fix: Allow configuring ofrep provider requests to api at base …

### DIFF
--- a/providers/openfeature-provider-ofrep/src/openfeature/contrib/provider/ofrep/__init__.py
+++ b/providers/openfeature-provider-ofrep/src/openfeature/contrib/provider/ofrep/__init__.py
@@ -107,6 +107,12 @@ class OFREPProvider(AbstractProvider):
             FlagType.OBJECT, flag_key, default_value, evaluation_context
         )
 
+    def _get_ofrep_api_url(self, api_version: str = "v1") -> str:
+        ofrep_base_url = (
+            self.base_url if self.base_url.endswith("/") else f"{self.base_url}/"
+        )
+        return urljoin(ofrep_base_url, f"ofrep/{api_version}/")
+
     def _resolve(
         self,
         flag_type: FlagType,
@@ -124,7 +130,7 @@ class OFREPProvider(AbstractProvider):
 
         try:
             response = self.session.post(
-                urljoin(self.base_url, f"/ofrep/v1/evaluate/flags/{flag_key}"),
+                urljoin(self._get_ofrep_api_url(), f"evaluate/flags/{flag_key}"),
                 json=_build_request_data(evaluation_context),
                 timeout=self.timeout,
                 headers=self.headers_factory() if self.headers_factory else None,

--- a/providers/openfeature-provider-ofrep/tests/test_provider.py
+++ b/providers/openfeature-provider-ofrep/tests/test_provider.py
@@ -164,3 +164,17 @@ def test_provider_typecheck_flag_value(ofrep_provider, requests_mock):
 
     with pytest.raises(TypeMismatchError):
         ofrep_provider.resolve_boolean_details("flag_key", False)
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://localhost:8080",
+        "https://localhost:8080/",
+        "https://localhost:8080/tools/feature_flags",
+        "https://localhost:8080/tools/feature_flags/",
+    ],
+)
+def test_provider_api_path_resolution(base_url):
+    provider = OFREPProvider(base_url=base_url)
+    assert provider._get_ofrep_api_url() == f"{base_url.rstrip('/')}/ofrep/v1/"


### PR DESCRIPTION
## This PR

This PR updates the use of `urljoin` in the OFREP Provider so that api's at a base path other than "/" are supported.

### Related Issues

Fixes #141 

### How to test
<!-- if applicable, add testing instructions under this section -->

