### PR TITLE
feat: Add Flipt provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ docs/_build/
 
 # Virtual env directories
 .venv
+
+# vscode
+.vscode/

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "hooks/openfeature-hooks-opentelemetry": "0.1.3",
   "providers/openfeature-provider-flagd": "0.1.5",
-  "providers/openfeature-provider-ofrep": "0.1.0"
+  "providers/openfeature-provider-ofrep": "0.1.0",
+  "providers/openfeature-provider-flipt": "0.1.0"
 }

--- a/providers/openfeature-provider-flipt/LICENSE
+++ b/providers/openfeature-provider-flipt/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/providers/openfeature-provider-flipt/README.md
+++ b/providers/openfeature-provider-flipt/README.md
@@ -1,0 +1,31 @@
+# openfeature-provider-flipt
+
+This provider is designed to evaluate feature flags against the Flipt api using Flipt's [OpenFeature remote evaluation protocol (OFREP)](https://docs.flipt.io/reference/openfeature/overview) API. This is a remote evaluation.
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install openfeature-provider-flipt
+```
+
+## Configuration
+
+```python
+from openfeature import api
+from openfeature.contrib.provider.flipt import FliptProvider
+
+api.set_provider(FliptProvider(base_url="<flipt instance>", namespace="<your flipt feature flag namespace>"))
+client = api.get_client()
+client.get_boolean_value("<your feature flag key>", True)
+```
+
+## License
+
+Apache 2.0 - See [LICENSE](./LICENSE) for more information.

--- a/providers/openfeature-provider-flipt/pyproject.toml
+++ b/providers/openfeature-provider-flipt/pyproject.toml
@@ -1,0 +1,85 @@
+# pyproject.toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "openfeature-provider-flipt"
+version = "0.1.0"
+description = "OpenFeature provider for the Flipt feature flagging service"
+readme = "README.md"
+authors = [{ name = "OpenFeature", email = "openfeature-core@groups.io" }]
+license = { file = "LICENSE" }
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
+keywords = []
+dependencies = [
+  "openfeature-sdk>=0.7.0",
+  "openfeature-provider-ofrep>=0.1.0",
+]
+requires-python = ">=3.8"
+
+[project.urls]
+Homepage = "https://github.com/open-feature/python-sdk-contrib"
+
+[tool.hatch]
+
+[tool.hatch.envs.hatch-test]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+  "requests-mock",
+]
+
+[tool.hatch.envs.hatch-test.scripts]
+run = "pytest {args:tests}"
+run-cov = "coverage run -m pytest {args:tests}"
+cov-combine = "coverage combine"
+cov-report = [
+  "coverage xml",
+  "coverage html",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[tool.hatch.envs.mypy]
+dependencies = [
+  "mypy[faster-cache]>=1.13.0",
+  "types-requests",
+]
+
+[tool.hatch.envs.mypy.scripts]
+run = "mypy"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  ".gitignore",
+  "schemas",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/openfeature"]
+
+[tool.coverage.run]
+omit = [
+  "tests/**",
+]
+
+[tool.mypy]
+mypy_path = "src"
+files = "src"
+
+python_version = "3.8" # should be identical to the minimum supported version
+namespace_packages = true
+explicit_package_bases = true
+local_partial_types = true
+pretty = true
+
+strict = true
+disallow_any_generics = false

--- a/providers/openfeature-provider-flipt/src/openfeature/contrib/provider/flipt/__init__.py
+++ b/providers/openfeature-provider-flipt/src/openfeature/contrib/provider/flipt/__init__.py
@@ -1,0 +1,57 @@
+from typing import Callable, Dict, Optional
+
+from openfeature.contrib.provider.ofrep import OFREPProvider
+from openfeature.provider import Metadata
+
+# Only export the FliptProvider class symbol form the package
+__all__ = ["FliptProvider"]
+
+
+class FliptProvider(OFREPProvider):
+    """A provider for Flipt feature flags service that extends the OFREP Provider for interacting with Flipt's OFREP API"""
+
+    def __init__(
+        self,
+        base_url: str,
+        namespace: str,
+        *,
+        headers_factory: Optional[Callable[[], Dict[str, str]]] = None,
+        timeout: float = 5.0,
+    ):
+        """Override the OFREPProvider constructor to add a namespace parameter"""
+
+        # Build a headers factory function that includes the Flipt namespace header
+        headers_factory = self._resolve_header_factory(namespace, headers_factory)
+        super().__init__(base_url, headers_factory=headers_factory, timeout=timeout)
+
+    def _resolve_header_factory(
+        self, namespace: str, headers_factory: Optional[Callable[[], Dict[str, str]]]
+    ) -> Callable[[], Dict[str, str]]:
+        """
+        Resolves and returns a headers factory callable that includes the "X-Flipt-Namespace" header.
+
+        If a headers factory is provided, it will be called and its headers will be merged with the
+        "X-Flipt-Namespace" header. If no headers factory is provided, a new factory will be created
+        that only includes the "X-Flipt-Namespace" header.
+
+        Args:
+            namespace (str): The namespace value to be included in the "X-Flipt-Namespace" header.
+            headers_factory (Optional[Callable[[], Dict[str, str]]]): An optional callable that returns
+                a dictionary of headers.
+
+        Returns:
+            Callable[[], Dict[str, str]]: A callable that returns a dictionary of headers including
+            the "X-Flipt-Namespace" header.
+        """
+        if headers_factory is None:
+            headers = {"X-Flipt-Namespace": namespace}
+        else:
+            headers = {
+                **headers_factory(),
+                "X-Flipt-Namespace": namespace,
+            }
+
+        return lambda: headers
+
+    def get_metadata(self) -> Metadata:
+        return Metadata(name="Flipt Provider")

--- a/providers/openfeature-provider-flipt/tests/conftest.py
+++ b/providers/openfeature-provider-flipt/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from openfeature.contrib.provider.flipt import FliptProvider
+
+
+@pytest.fixture
+def flipt_provider():
+    return FliptProvider("http://localhost:8080")

--- a/providers/openfeature-provider-flipt/tests/test_provider.py
+++ b/providers/openfeature-provider-flipt/tests/test_provider.py
@@ -1,0 +1,185 @@
+import pytest
+
+from openfeature.contrib.provider.flipt import FliptProvider
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.exception import (
+    FlagNotFoundError,
+    GeneralError,
+    InvalidContextError,
+    ParseError,
+    TypeMismatchError,
+)
+from openfeature.flag_evaluation import FlagResolutionDetails, Reason
+
+
+@pytest.mark.parametrize(
+    "headers_factory_fixture", [None, lambda: {"Authorization": "Bearer token"}]
+)
+def test_flipt_provider_init(headers_factory_fixture):
+    """Test that the FliptProvider correctly initializes and merges the headers factory with the namespace header"""
+    provider = FliptProvider(
+        "http://localhost:8080",
+        "test-namespace",
+        headers_factory=headers_factory_fixture,
+    )
+    assert provider.base_url == "http://localhost:8080"
+    if headers_factory_fixture:
+        assert provider.headers_factory() == {
+            **headers_factory_fixture(),
+            "X-Flipt-Namespace": "test-namespace",
+        }
+    else:
+        assert provider.headers_factory() == {
+            "X-Flipt-Namespace": "test-namespace",
+        }
+
+
+@pytest.mark.parametrize(
+    "get_method, resolved_value, default_value",
+    (
+        ("resolve_boolean_details", True, False),
+        ("resolve_string_details", "resolved_flag_str", "default_flag_str"),
+        ("resolve_integer_details", 100, 0),
+        ("resolve_float_details", 10.23, 0.0),
+        (
+            "resolve_object_details",
+            {
+                "String": "string",
+                "Number": 2,
+                "Boolean": True,
+            },
+            {},
+        ),
+        ("resolve_object_details", ["string1", "string2"], []),
+    ),
+)
+def test_flipt_provider_successful_resolution(
+    get_method, resolved_value, default_value, requests_mock
+):
+    """Mock any call to Flipt OFREP api and validat that the resolution function for each type returns the expected FlagResolutionDetails"""
+
+    provider = FliptProvider("http://localhost:8080", "test-namespace")
+    requests_mock.post(
+        "http://localhost:8080/ofrep/v1/evaluate/flags/flag_key",
+        json={
+            "key": "flag_key",
+            "reason": "TARGETING_MATCH",
+            "variant": str(resolved_value),
+            "metadata": {"foo": "bar"},
+            "value": resolved_value,
+        },
+    )
+
+    resolution = getattr(provider, get_method)("flag_key", default_value)
+
+    assert resolution == FlagResolutionDetails(
+        value=resolved_value,
+        reason=Reason.TARGETING_MATCH,
+        variant=str(resolved_value),
+        flag_metadata={"foo": "bar"},
+    )
+
+
+def test_flipt_provider_flag_not_found(requests_mock):
+    provider = FliptProvider("http://localhost:8080", "test-namespace")
+    requests_mock.post(
+        "http://localhost:8080/ofrep/v1/evaluate/flags/flag_key",
+        status_code=404,
+        json={
+            "key": "flag_key",
+            "errorCode": "FLAG_NOT_FOUND",
+            "errorDetails": "Flag 'flag_key' not found",
+        },
+    )
+
+    with pytest.raises(FlagNotFoundError):
+        provider.resolve_boolean_details("flag_key", False)
+
+
+def test_flipt_provider_invalid_context(requests_mock):
+    provider = FliptProvider("http://localhost:8080", "test-namespace")
+    requests_mock.post(
+        "http://localhost:8080/ofrep/v1/evaluate/flags/flag_key",
+        status_code=400,
+        json={
+            "key": "flag_key",
+            "errorCode": "INVALID_CONTEXT",
+            "errorDetails": "Invalid context provided",
+        },
+    )
+
+    with pytest.raises(InvalidContextError):
+        provider.resolve_boolean_details("flag_key", False)
+
+
+def test_flipt_provider_invalid_response(requests_mock):
+    provider = FliptProvider("http://localhost:8080", "test-namespace")
+    requests_mock.post(
+        "http://localhost:8080/ofrep/v1/evaluate/flags/flag_key", text="invalid"
+    )
+
+    with pytest.raises(ParseError):
+        provider.resolve_boolean_details("flag_key", False)
+
+
+def test_flipt_provider_evaluation_context(requests_mock):
+    provider = FliptProvider("http://localhost:8080", "test-namespace")
+
+    def match_request_json(request):
+        return request.json() == {"context": {"targetingKey": "1", "foo": "bar"}}
+
+    requests_mock.post(
+        "http://localhost:8080/ofrep/v1/evaluate/flags/flag_key",
+        json={
+            "key": "flag_key",
+            "reason": "TARGETING_MATCH",
+            "variant": "true",
+            "metadata": {},
+            "value": True,
+        },
+        additional_matcher=match_request_json,
+    )
+
+    context = EvaluationContext("1", {"foo": "bar"})
+    resolution = provider.resolve_boolean_details(
+        "flag_key", False, evaluation_context=context
+    )
+
+    assert resolution == FlagResolutionDetails(
+        value=True,
+        reason=Reason.TARGETING_MATCH,
+        variant="true",
+    )
+
+
+def test_flipt_provider_retry_after_shortcircuit_resolution(requests_mock):
+    provider = FliptProvider("http://localhost:8080", "test-namespace")
+    requests_mock.post(
+        "http://localhost:8080/ofrep/v1/evaluate/flags/flag_key",
+        status_code=429,
+        headers={"Retry-After": "1"},
+    )
+
+    with pytest.raises(GeneralError, match="Rate limited, retry after: 1"):
+        provider.resolve_boolean_details("flag_key", False)
+    with pytest.raises(
+        GeneralError, match="OFREP evaluation paused due to TooManyRequests"
+    ):
+        provider.resolve_boolean_details("flag_key", False)
+
+
+def test_flipt_provider_typecheck_flag_value(requests_mock):
+    provider = FliptProvider("http://localhost:8080", "test-namespace")
+    requests_mock.post(
+        "http://localhost:8080/ofrep/v1/evaluate/flags/flag_key",
+        json={
+            "key": "flag_key",
+            "reason": "TARGETING_MATCH",
+            "variant": "true",
+            "metadata": {},
+            "value": "true",
+        },
+    )
+
+    with pytest.raises(TypeMismatchError):
+        provider.resolve_boolean_details("flag_key", False)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,15 @@
         "README.md"
       ]
     },
+    "providers/openfeature-provider-flipt": {
+      "package-name": "openfeature-provider-flipt",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default",
+      "extra-files": [
+        "README.md"
+      ]
+    },
     "hooks/openfeature-hooks-opentelemetry": {
       "package-name": "openfeature-hooks-opentelemetry",
       "bump-minor-pre-major": true,


### PR DESCRIPTION

## Overview

This PR implements the Flipt provider by wrapping around the OFREP Provider and leveraging Flipt's OFREP api

## Discussion Points:
- Should we support passing the namespace in the constructor this way or just leave it up to users to do it themselves via the generic headers_factory (like they would need to for authentication)


### Related Issues
Fixes #89 


### How to test

Unit Tests: From the base of the package run `hatch test`

Local Usage: Go to the base of the new packager (i.e. `provider/openfeature-provider-flipt`), run `pip install -e .`, and then open a python repl with `python3`:
```python
from openfeature import api
from openfeature.contrib.provider.flipt import FliptProvider
api.set_provider(FliptProvider(base_url="<flipt instance>", namespace="<your namespace>"))
client = api.get_client()
client.get_boolean_value("<your feature flag key>", True)
```

