### PR TITLE
fix: Pin the ofrep provider's requests dep >=2.27.0 because of…

### DIFF
--- a/providers/openfeature-provider-ofrep/pyproject.toml
+++ b/providers/openfeature-provider-ofrep/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 keywords = []
 dependencies = [
   "openfeature-sdk>=0.7.0",
-  "requests"
+  "requests>=2.27.0"
 ]
 requires-python = ">=3.8"
 


### PR DESCRIPTION
**Description:** The ofrep provider uses JSONDecodeError from `requests.exceptions`. This is not available till requests >= 2.27 so update the package deps in `pyproject.toml`

**Issue:** https://github.com/open-feature/python-sdk-contrib/issues/156

