### PR TITLE
feat: [WIP] Add the open feature flipt client. Tests still required

### DIFF
--- a/providers/openfeature-provider-flipt-client/LICENSE
+++ b/providers/openfeature-provider-flipt-client/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/providers/openfeature-provider-flipt-client/README.md
+++ b/providers/openfeature-provider-flipt-client/README.md
@@ -1,0 +1,37 @@
+# OpenFeature Flipt Client-Side Provider
+
+This provider is designed to support client side evaluation of feature flags for Flipt feature flag provider.
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install openfeature-provider-flipt-client
+```
+
+## Configuration
+
+```python
+from openfeature.contrib.provider.flipt_client import (
+    FliptClientProvider,
+)
+
+FliptClientProvider(
+    base_url="",
+    Client
+)
+
+
+```
+
+
+
+## License
+
+Apache 2.0 - See [LICENSE](./LICENSE) for more information.

--- a/providers/openfeature-provider-flipt-client/pyproject.toml
+++ b/providers/openfeature-provider-flipt-client/pyproject.toml
@@ -1,0 +1,85 @@
+# pyproject.toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "openfeature-provider-flipt-client"
+version = "0.1.0"
+description = "OpenFeature provider supporting client-side evaluation for the Flipt feature flagging service"
+readme = "README.md"
+authors = [{ name = "OpenFeature", email = "openfeature-core@groups.io" }]
+license = { file = "LICENSE" }
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
+keywords = []
+dependencies = [
+  "flipt-client>=0.14.0",
+  "openfeature-sdk>=0.7.0",
+]
+requires-python = ">=3.9"
+
+[project.urls]
+Homepage = "https://github.com/open-feature/python-sdk-contrib"
+
+[tool.hatch]
+
+[tool.hatch.envs.hatch-test]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+  "requests-mock",
+]
+
+[tool.hatch.envs.hatch-test.scripts]
+run = "pytest {args:tests}"
+run-cov = "coverage run -m pytest {args:tests}"
+cov-combine = "coverage combine"
+cov-report = [
+  "coverage xml",
+  "coverage html",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[tool.hatch.envs.mypy]
+dependencies = [
+  "mypy[faster-cache]>=1.13.0",
+  "types-requests",
+]
+
+[tool.hatch.envs.mypy.scripts]
+run = "mypy"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  ".gitignore",
+  "schemas",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/openfeature"]
+
+[tool.coverage.run]
+omit = [
+  "tests/**",
+]
+
+[tool.mypy]
+mypy_path = "src"
+files = "src"
+
+python_version = "3.9" # should be identical to the minimum supported version
+namespace_packages = true
+explicit_package_bases = true
+local_partial_types = true
+pretty = true
+
+strict = true
+disallow_any_generics = false

--- a/providers/openfeature-provider-flipt-client/src/openfeature/contrib/provider/flipt-client/__init__.py
+++ b/providers/openfeature-provider-flipt-client/src/openfeature/contrib/provider/flipt-client/__init__.py
@@ -1,0 +1,235 @@
+from typing import Optional, Union, Any
+
+from enum import Enum
+from openfeature.provider import AbstractProvider, Metadata
+from flipt_client.models import (
+    FetchMode, 
+    AuthenticationStrategy, 
+    ClientTokenAuthentication,
+    JWTAuthentication,
+    ClientOptions
+)
+from flipt_client import FliptEvaluationClient
+
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.exception import ErrorCode
+from openfeature.flag_evaluation import FlagResolutionDetails, Reason, FlagType
+
+# Expose the provider and relevant models
+__all__ = ['FliptClientProvider', 'ClientTokenAuthentication', 'JWTAuthentication', 'FetchMode'] 
+
+
+class FliptClientProvider(AbstractProvider):
+    '''Wrapper for the Flipt Evaluation Client with the standard OpenFeature Provider interface'''
+
+    def __init__(
+        self,
+        base_url: str,
+        namespace: str = 'default',
+        *,
+        update_interval: Optional[int] = None,
+        authentication: Optional[AuthenticationStrategy] = None,
+        reference: Optional[str] = None,
+        fetch_mode: Optional[FetchMode] = None
+    ):
+        self._client=FliptEvaluationClient(
+            namespace=namespace,
+            opts=ClientOptions(
+                url=base_url,
+                update_interval=update_interval,
+                authentication=authentication,
+                reference=reference,
+                fetch_mode=fetch_mode
+            )
+        )
+    
+    def get_metadata(self) -> Metadata:
+        return Metadata(
+            name='OpenFeature Flipt Client-Side Provider',
+        )
+
+    def get_provider_hooks(self):
+        return []
+ 
+    def _get_entity_id(self, evaluation_context: EvaluationContext) -> str:
+        return "" if not evaluation_context.targeting_key else evaluation_context.targeting_key
+
+    def resolve_boolean_details(
+        self,
+        flag_key: str,
+        default_value: bool,
+        evaluation_context: Optional[EvaluationContext]
+    ) -> FlagResolutionDetails[bool]:
+        '''Resolve the boolean value of a flag from Flipt'''
+        if not flag_key or not flag_key.strip():
+            raise ValueError("flag_key cannot be empty or None")
+       
+        try:
+            eval_response = self._client.evaluate_boolean(
+                flag_key=flag_key,
+                entity_id=self._get_entity_id(evaluation_context),
+                context=evaluation_context.attributes
+            )
+        except Exception as e:
+            return FlagResolutionDetails(
+                value=default_value,
+                reason=Reason.ERROR,
+                error_message=str(e),
+                error_code=None ## Explicitly set to None. No clear mapping atm from Flipt error to OpenFeature error codes
+            )
+        
+        return FlagResolutionDetails(
+            value=eval_response.enabled,
+            reason=FliptEvaluationReason(eval_response.reason).to_openfeature_reason(), ## Pass through the flipt reason str
+            flag_metadata={ 
+                "timestamp": eval_response.timestamp, 
+                "request_duration_millis": eval_response.request_duration_millis }
+        )
+
+    def _validate_flag_type(self, flag_type: FlagType, default_value: Any):
+        '''Validate the default value type against the expected flag type'''
+        if flag_type == FlagType.BOOLEAN:
+            assert isinstance(default_value, bool)
+        elif flag_type == FlagType.STRING:
+            assert isinstance(default_value, str)
+        elif flag_type == FlagType.INTEGER:
+            assert isinstance(default_value, int)
+        elif flag_type == FlagType.FLOAT:
+            assert isinstance(default_value, float)
+        elif flag_type == FlagType.OBJECT:
+            assert isinstance(default_value, dict) or isinstance(default_value, list)
+    
+    def _resolve_flag_details(
+            self,
+            flag_key: str,
+            flag_type: FlagType,
+            default_value: Any,
+            evaluation_context: Optional[EvaluationContext] = None,
+        ):
+        ''' Resolve a variant with strict typing around return value'''
+        if not flag_key or not flag_key.strip():
+            raise ValueError("flag_key cannot be empty or None")
+
+        ## Assert the default value matches the expected type
+        try:
+            self._validate_flag_type(flag_type, default_value)
+        except AssertionError:
+            raise Exception(f"Default value {default_value} does not match the expected evaluation type {flag_type}")
+
+        try:
+            eval_response = self._client.evaluate_variant(
+                flag_key=flag_key,
+                entity_id=self._get_entity_id(evaluation_context),
+                context=evaluation_context.attributes
+            )
+        except Exception as e:
+            return FlagResolutionDetails(
+                value=default_value,
+                reason=Reason.ERROR,
+                error_message=str(e),
+                error_code=None ## Explicitly set to None. No clear mapping atm from Flipt error to OpenFeature error codes
+            )
+        
+        flag_value = eval_response.variant_attachment if flag_type == FlagType.OBJECT else eval_response.variant_key
+        
+        ## Assert the default value matches the expected type
+        try:
+            self._validate_flag_type(flag_type, flag_value)
+        except AssertionError as e:
+            return FlagResolutionDetails(
+                value=default_value,
+                reason=Reason.ERROR,
+                error_message=str(e),
+                error_code=ErrorCode.TYPE_MISMATCH 
+            )
+          
+        
+        return FlagResolutionDetails(
+            value=flag_value,
+            reason=FliptEvaluationReason(eval_response.reason).to_openfeature_reason(), ## Pass through the flipt reason str
+            flag_metadata={ 
+                "timestamp": eval_response.timestamp, 
+                "request_duration_millis": eval_response.request_duration_millis }
+        )
+    
+    def resolve_string_details(
+        self,
+        flag_key: str,
+        default_value: str,
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[str]:
+        self._resolve_flag_details(
+            flag_key=flag_key,
+            flag_type=FlagType.STRING,
+            default_value=default_value,
+            evaluation_context=evaluation_context,
+        )
+
+    def resolve_integer_details(
+        self,
+        flag_key: str,
+        default_value: int,
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[int]:
+        self._resolve_flag_details(
+            flag_key=flag_key,
+            flag_type=FlagType.INTEGER,
+            default_value=default_value,
+            evaluation_context=evaluation_context,
+        )
+    
+    def resolve_float_details(
+        self,
+        flag_key: str,
+        default_value: float,
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[float]:
+        self._resolve_flag_details(
+            flag_key=flag_key,
+            flag_type=FlagType.FLOAT,
+            default_value=default_value,
+            evaluation_context=evaluation_context,
+        )
+    
+    def resolve_object_details(
+        self,
+        flag_key: str,
+        default_value: Union[dict, list],
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[Union[dict, list]]:
+        self._resolve_flag_details(
+            flag_key=flag_key,
+            flag_type=FlagType.OBJECT,
+            default_value=default_value,
+            evaluation_context=evaluation_context,
+        )
+
+
+class FliptEvaluationReason(Enum, str):
+    '''Enum for the FliptClientProvider evaluation reasons'''
+    FLAG_DISABLED = 'FLAG_DISABLED_EVALUATION_REASON'
+    MATCH = 'MATCH_EVALUATION_REASON'
+    DEFAULT = 'DEFAULT_EVALUATION_REASON'
+    UNKNOWN = 'UNKNOWN_EVALUATION_REASON'
+
+    @staticmethod
+    def from_str(reason: str) -> Union['FliptEvaluationReason', str]:
+        '''Convert a Flipt reason string to a FliptEvaluationReason enum'''
+        try:
+            return FliptEvaluationReason(reason)
+        except ValueError:
+            return reason
+
+    def to_openfeature_reason(self) -> Union[Reason, str]:
+        '''Convert the FliptEvaluationReason to an OpenFeature Reason'''
+        if self == FliptEvaluationReason.FLAG_DISABLED:
+            return Reason.DISABLED
+        elif self == FliptEvaluationReason.MATCH:
+            return Reason.TARGETING_MATCH
+        elif self == FliptEvaluationReason.DEFAULT:
+            return Reason.DEFAULT
+        elif self == FliptEvaluationReason.UNKNOWN:
+            return Reason.UNKNOWN
+        else:
+            return str
+


### PR DESCRIPTION
## This PR

**Background:**
This PR adds a new provider to support flipt-client evaluation. This provider more flexibility to end users looking to consume from the Flipt and it allows OpenFeature to be used directly alongside Flipt Cloud which only supports the Client side sdk atm (self-hosted supports both client and server side sdks).

**Implementation**
- Flipt Client Provider is an adapter around the Official Flipt Client SDK
- The Evalation API is implemented with strict typing meaning
  - default_value provided has a type assertion done for the expected evaluation type (str, int, float, dict, list)
  - the type of the  returned response from the official sdk is checked. If TYPE_MISMATCH occurs then the default is returned and appropriate error code and reason are in the evaluation details
- I have tried my best to map FliptEvaluationReasons that I see in (https://github.com/flipt-io/flipt-client-sdks/blob/7f6be0aaee75938e5b235344451d898d583c0fe9/flipt-evaluation/src/models/flipt.rs#L144) and the js providers mapping of flipt Reasons (https://github.com/open-feature/js-sdk-contrib/blob/main/libs/providers/flipt-web/src/lib/models.ts#L17) over to the generic OpenFeature reasons where possible but the Official Flipt client SDK does not define an Enum of reasons and the OpenFeature Reson's field support a Reson enum or Str _so where mapping cannot be done cleanly the reason string returned from the flipt client sdk is passed through transparently_


### Related Issues
#163 

### Follow-up Tasks
> NOTE: Tests are still WIP

