### PR TITLE
feat(flagd): Context value hydration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "providers/openfeature-provider-flagd/test-harness"]
 	path = providers/openfeature-provider-flagd/openfeature/test-harness
 	url = git@github.com:open-feature/flagd-testbed.git
-	branch = v2.2.0
+	branch = v2.5.0
 [submodule "providers/openfeature-provider-flagd/spec"]
 	path = providers/openfeature-provider-flagd/openfeature/spec
 	url = https://github.com/open-feature/spec

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/provider.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/provider.py
@@ -125,7 +125,7 @@ class FlagdProvider(AbstractProvider):
         ):
             return InProcessResolver(
                 self.config,
-                self.on_provider_ready,
+                self.emit_provider_ready_with_context,
                 self.emit_provider_error,
                 self.emit_provider_stale,
                 self.emit_provider_configuration_changed,
@@ -196,7 +196,9 @@ class FlagdProvider(AbstractProvider):
             key, default_value, evaluation_context
         )
 
-    def on_provider_ready(self, details: ProviderEventDetails, metadata: dict) -> None:
-        self.enriched_context = metadata
+    def emit_provider_ready_with_context(
+        self, details: ProviderEventDetails, context: dict
+    ) -> None:
+        self.enriched_context = context
         self.emit_provider_ready(details)
         pass

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/provider.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/provider.py
@@ -25,12 +25,15 @@ import typing
 import warnings
 
 from openfeature.evaluation_context import EvaluationContext
+from openfeature.event import ProviderEventDetails
 from openfeature.flag_evaluation import FlagResolutionDetails
+from openfeature.hook import Hook
 from openfeature.provider import AbstractProvider
 from openfeature.provider.metadata import Metadata
 
 from .config import CacheType, Config, ResolverType
 from .resolvers import AbstractResolver, GrpcResolver, InProcessResolver
+from .sync_metadata_hook import SyncMetadataHook
 
 T = typing.TypeVar("T")
 
@@ -96,8 +99,16 @@ class FlagdProvider(AbstractProvider):
             max_cache_size=max_cache_size,
             cert_path=cert_path,
         )
+        self.enriched_context: dict = {}
 
         self.resolver = self.setup_resolver()
+        self.hooks: list[Hook] = [SyncMetadataHook(self.get_enriched_context)]
+
+    def get_enriched_context(self) -> EvaluationContext:
+        return EvaluationContext(attributes=self.enriched_context)
+
+    def get_provider_hooks(self) -> list[Hook]:
+        return self.hooks
 
     def setup_resolver(self) -> AbstractResolver:
         if self.config.resolver == ResolverType.RPC:
@@ -114,7 +125,7 @@ class FlagdProvider(AbstractProvider):
         ):
             return InProcessResolver(
                 self.config,
-                self.emit_provider_ready,
+                self.on_provider_ready,
                 self.emit_provider_error,
                 self.emit_provider_stale,
                 self.emit_provider_configuration_changed,
@@ -184,3 +195,8 @@ class FlagdProvider(AbstractProvider):
         return self.resolver.resolve_object_details(
             key, default_value, evaluation_context
         )
+
+    def on_provider_ready(self, details: ProviderEventDetails, metadata: dict) -> None:
+        self.enriched_context = metadata
+        self.emit_provider_ready(details)
+        pass

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/grpc.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/grpc.py
@@ -276,7 +276,7 @@ class GrpcResolver:
             return cached_flag
 
         context = self._convert_context(evaluation_context)
-        call_args = {"timeout": self.deadline}
+        call_args = {"timeout": self.deadline, "wait_for_ready": True}
         try:
             request: Message
             if flag_type == FlagType.BOOLEAN:

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/grpc.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/grpc.py
@@ -137,7 +137,10 @@ class GrpcResolver:
 
     def _state_change_callback(self, new_state: ChannelConnectivity) -> None:
         logger.debug(f"gRPC state change: {new_state}")
-        if new_state == ChannelConnectivity.READY:
+        if (
+            new_state == grpc.ChannelConnectivity.READY
+            or new_state == grpc.ChannelConnectivity.IDLE
+        ):
             if not self.thread or not self.thread.is_alive():
                 self.thread = threading.Thread(
                     target=self.listen,

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/in_process.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/in_process.py
@@ -21,7 +21,7 @@ class InProcessResolver:
     def __init__(
         self,
         config: Config,
-        emit_provider_ready: typing.Callable[[ProviderEventDetails], None],
+        emit_provider_ready: typing.Callable[[ProviderEventDetails, dict], None],
         emit_provider_error: typing.Callable[[ProviderEventDetails], None],
         emit_provider_stale: typing.Callable[[ProviderEventDetails], None],
         emit_provider_configuration_changed: typing.Callable[

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/file_watcher.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/file_watcher.py
@@ -24,7 +24,7 @@ class FileWatcher(FlagStateConnector):
         self,
         config: Config,
         flag_store: FlagStore,
-        emit_provider_ready: typing.Callable[[ProviderEventDetails], None],
+        emit_provider_ready: typing.Callable[[ProviderEventDetails, dict], None],
         emit_provider_error: typing.Callable[[ProviderEventDetails], None],
     ):
         if config.offline_flag_source_path is None:
@@ -94,7 +94,8 @@ class FileWatcher(FlagStateConnector):
                 self.emit_provider_ready(
                     ProviderEventDetails(
                         message="Reloading file contents recovered from error state"
-                    )
+                    ),
+                    {},
                 )
                 self.should_emit_ready_on_success = False
 

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
@@ -107,7 +107,10 @@ class GrpcWatcher(FlagStateConnector):
 
     def _state_change_callback(self, new_state: grpc.ChannelConnectivity) -> None:
         logger.debug(f"gRPC state change: {new_state}")
-        if new_state == grpc.ChannelConnectivity.READY:
+        if (
+            new_state == grpc.ChannelConnectivity.READY
+            or new_state == grpc.ChannelConnectivity.IDLE
+        ):
             if not self.thread or not self.thread.is_alive():
                 self.thread = threading.Thread(
                     target=self.listen,

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/sync_metadata_hook.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/sync_metadata_hook.py
@@ -1,0 +1,14 @@
+import typing
+
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.hook import Hook, HookContext, HookHints
+
+
+class SyncMetadataHook(Hook):
+    def __init__(self, context_supplier: typing.Callable[[], EvaluationContext]):
+        self.context_supplier = context_supplier
+
+    def before(
+        self, hook_context: HookContext, hints: HookHints
+    ) -> typing.Optional[EvaluationContext]:
+        return self.context_supplier()

--- a/providers/openfeature-provider-flagd/tests/e2e/file/conftest.py
+++ b/providers/openfeature-provider-flagd/tests/e2e/file/conftest.py
@@ -12,6 +12,7 @@ feature_list = {
     "~sync",
     "~caching",
     "~grace",
+    "~contextEnrichment",
 }
 
 


### PR DESCRIPTION
This pr adds context value hydration to the in-process evaluator.

This means, that flagd will provide contextual attributes on connection startup which will be used for inprocess evaluation, like defined in the spec.

https://flagd.dev/reference/specifications/providers/#sync-metadata-properties-in-the-evaluation-context

Follow-up:
- [ ] make contextEnricher a config attribute

