### PR TITLE
chore(flagd): Add sync metadata disabled

### DIFF
--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/config.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/config.py
@@ -253,7 +253,7 @@ class Config:
         # TODO: remove the metadata call entirely after https://github.com/open-feature/flagd/issues/1584
         # This is a temporary stop-gap solutions to support servers that don't implement sync.GetMetadata
         # (see: https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.FlagSyncService.GetMetadata).
-        # Using this option sisables call to sync.GetMetadata
+        # Using this option disables call to sync.GetMetadata
         # Disabling will prevent static context from flagd being used in evaluations.
         # GetMetadata and this option will be removed.
         self.sync_metadata_disabled = sync_metadata_disabled

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/config.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/config.py
@@ -100,6 +100,7 @@ class Config:
         cert_path: typing.Optional[str] = None,
         default_authority: typing.Optional[str] = None,
         channel_credentials: typing.Optional[grpc.ChannelCredentials] = None,
+        sync_metadata_disabled: typing.Optional[bool] = None,
     ):
         self.host = env_or_default(ENV_VAR_HOST, DEFAULT_HOST) if host is None else host
 
@@ -248,3 +249,11 @@ class Config:
         )
 
         self.channel_credentials = channel_credentials
+
+        # TODO: remove the metadata call entirely after https://github.com/open-feature/flagd/issues/1584
+        # This is a temporary stop-gap solutions to support servers that don't implement sync.GetMetadata
+        # (see: https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.FlagSyncService.GetMetadata).
+        # Using this option sisables call to sync.GetMetadata
+        # Disabling will prevent static context from flagd being used in evaluations.
+        # GetMetadata and this option will be removed.
+        self.sync_metadata_disabled = sync_metadata_disabled

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/provider.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/provider.py
@@ -64,6 +64,7 @@ class FlagdProvider(AbstractProvider):
         cert_path: typing.Optional[str] = None,
         default_authority: typing.Optional[str] = None,
         channel_credentials: typing.Optional[grpc.ChannelCredentials] = None,
+        sync_metadata_disabled: typing.Optional[bool] = None,
     ):
         """
         Create an instance of the FlagdProvider
@@ -106,6 +107,7 @@ class FlagdProvider(AbstractProvider):
             cert_path=cert_path,
             default_authority=default_authority,
             channel_credentials=channel_credentials,
+            sync_metadata_disabled=sync_metadata_disabled,
         )
         self.enriched_context: dict = {}
 

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
@@ -163,17 +163,22 @@ class GrpcWatcher(FlagStateConnector):
         self.active = False
         self.channel.close()
 
+    def _create_request_args(self) -> dict:
+        request_args = {}
+        if self.selector is not None:
+            request_args["selector"] = self.selector
+        if self.provider_id is not None:
+            request_args["provider_id"] = self.provider_id
+
+        return request_args
+
     def listen(self) -> None:
         call_args = (
             {"timeout": self.streamline_deadline_seconds}
             if self.streamline_deadline_seconds > 0
             else {}
         )
-        request_args = {}
-        if self.selector is not None:
-            request_args["selector"] = self.selector
-        if self.provider_id is not None:
-            request_args["provider_id"] = self.provider_id
+        request_args = self._create_request_args()
 
         while self.active:
             try:


### PR DESCRIPTION
## This PR
- Adds option which disables GetMetadata call

### Related Issues
- https://github.com/open-feature/flagd/issues/1584

### Notes
`GetMetadata` call was recently added in https://github.com/open-feature/python-sdk-contrib/pull/195. This is potentially breaking for server implementations that don't support metadata. As such, this PR is a temporary stop-gap for such implementations, and it will be removed when metadata is deprecated with the completion of the above issue.

There's no need to implement this in all languages, we'll do it at maintainer discretion according to user need.

This is similar to recently added option in the Java SDK: https://github.com/open-feature/java-sdk-contrib/pull/1267

CC: @toddbaert @aepfli @gruebel 