### PR TITLE
fix: add retry policy to grpc calls.

### DIFF
--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/grpc.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/grpc.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import threading
 import time
@@ -80,6 +81,44 @@ class GrpcResolver:
             ("grpc.initial_reconnect_backoff_ms", config.retry_backoff_ms),
             ("grpc.max_reconnect_backoff_ms", config.retry_backoff_max_ms),
             ("grpc.min_reconnect_backoff_ms", config.deadline_ms),
+            (
+                "grpc.service_config",
+                json.dumps(
+                    {
+                        "methodConfig": [
+                            {
+                                "name": [
+                                    {"service": "flagd.sync.v1.FlagSyncService"},
+                                    {"service": "flagd.evaluation.v1.Service"},
+                                ],
+                                "retryPolicy": {
+                                    "maxAttempts": 3,
+                                    "initialBackoff": "1s",
+                                    "maxBackoff": "5s",
+                                    "backoffMultiplier": 2.0,
+                                    "retryableStatusCodes": [
+                                        "CANCELLED",
+                                        "UNKNOWN",
+                                        "INVALID_ARGUMENT",
+                                        "NOT_FOUND",
+                                        "ALREADY_EXISTS",
+                                        "PERMISSION_DENIED",
+                                        "RESOURCE_EXHAUSTED",
+                                        "FAILED_PRECONDITION",
+                                        "ABORTED",
+                                        "OUT_OF_RANGE",
+                                        "UNIMPLEMENTED",
+                                        "INTERNAL",
+                                        "UNAVAILABLE",
+                                        "DATA_LOSS",
+                                        "UNAUTHENTICATED",
+                                    ],
+                                },
+                            }
+                        ]
+                    }
+                ),
+            ),
         ]
         if config.tls:
             channel_args = {

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
@@ -62,6 +62,44 @@ class GrpcWatcher(FlagStateConnector):
             ("grpc.initial_reconnect_backoff_ms", config.retry_backoff_ms),
             ("grpc.max_reconnect_backoff_ms", config.retry_backoff_max_ms),
             ("grpc.min_reconnect_backoff_ms", config.stream_deadline_ms),
+            (
+                "grpc.service_config",
+                json.dumps(
+                    {
+                        "methodConfig": [
+                            {
+                                "name": [
+                                    {"service": "flagd.sync.v1.FlagSyncService"},
+                                    {"service": "flagd.evaluation.v1.Service"},
+                                ],
+                                "retryPolicy": {
+                                    "maxAttempts": 3,
+                                    "initialBackoff": "1s",
+                                    "maxBackoff": "5s",
+                                    "backoffMultiplier": 2.0,
+                                    "retryableStatusCodes": [
+                                        "CANCELLED",
+                                        "UNKNOWN",
+                                        "INVALID_ARGUMENT",
+                                        "NOT_FOUND",
+                                        "ALREADY_EXISTS",
+                                        "PERMISSION_DENIED",
+                                        "RESOURCE_EXHAUSTED",
+                                        "FAILED_PRECONDITION",
+                                        "ABORTED",
+                                        "OUT_OF_RANGE",
+                                        "UNIMPLEMENTED",
+                                        "INTERNAL",
+                                        "UNAVAILABLE",
+                                        "DATA_LOSS",
+                                        "UNAUTHENTICATED",
+                                    ],
+                                },
+                            }
+                        ]
+                    }
+                ),
+            ),
         ]
         if config.default_authority is not None:
             options.append(("grpc.default_authority", config.default_authority))


### PR DESCRIPTION
Some error codes are not on the stream, e.g., Istio is sending some special ones, and we already implemented the same logic in Java to bypass this issue. see https://github.com/open-feature/java-sdk-contrib/pull/1261
