### PR TITLE
fix(flagd): reduce loglevel of expected logs

### DIFF
--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
@@ -258,7 +258,7 @@ class GrpcWatcher(FlagStateConnector):
                         logger.debug("Terminating gRPC sync thread")
                         return
             except grpc.RpcError as e:  # noqa: PERF203
-                logger.error(f"SyncFlags stream error, {e.code()=} {e.details()=}")
+                logger.debug(f"SyncFlags stream error, {e.code()=} {e.details()=}")
             except json.JSONDecodeError:
                 logger.exception(
                     f"Could not parse JSON flag data from SyncFlags endpoint: {flag_str=}"


### PR DESCRIPTION
We're expecting to enter this error case. Connections are dropping regularly due to different issues. We will restart the connection, hence this is not worthy for an error-log.