### PR TITLE
feat: adjust to flagd metadata toggle

### DIFF
--- a/providers/openfeature-provider-flagd/tests/e2e/step/provider_steps.py
+++ b/providers/openfeature-provider-flagd/tests/e2e/step/provider_steps.py
@@ -32,6 +32,7 @@ class TestProviderType(Enum):
     SSL = "ssl"
     SOCKET = "socket"
     METADATA = "metadata"
+    SYNCPAYLOAD = "syncpayload"
 
 
 @given("a provider is registered", target_fixture="client")
@@ -71,6 +72,8 @@ def get_default_options_for_provider(
         return options, True
     elif t == TestProviderType.METADATA:
         launchpad = "metadata"
+    elif t == TestProviderType.SYNCPAYLOAD:
+        launchpad = "sync-payload"
 
     if resolver_type == ResolverType.FILE:
         if "selector" in option_values:


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adjusts the implementation to handle both paths that the `disable-sync-metadata` toggle introduces

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

closes https://github.com/open-feature/python-sdk-contrib/issues/278
relates https://github.com/open-feature/flagd/issues/1584
