### PR TITLE
fix(build): bump protobuf package version to a compatible version

### DIFF
--- a/providers/openfeature-provider-flagd/pyproject.toml
+++ b/providers/openfeature-provider-flagd/pyproject.toml
@@ -19,7 +19,7 @@ keywords = []
 dependencies = [
   "openfeature-sdk>=0.8.2",
   "grpcio>=1.68.1",
-  "protobuf>=5.26.1",
+  "protobuf>=5.29.5",
   "mmh3>=4.1.0",
   "panzi-json-logic>=1.0.1",
   "semver>=3,<4",
@@ -52,7 +52,7 @@ dev = [
 [tool.hatch.build.hooks.protobuf]
 generate_pyi = false
 dependencies = [
-    "protobuf==5.26.1",
+    "protobuf==5.29.5",
     "hatch-protobuf",
     "mypy-protobuf~=3.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ requires-dist = [
     { name = "mmh3", specifier = ">=4.1.0" },
     { name = "openfeature-sdk", specifier = ">=0.8.2" },
     { name = "panzi-json-logic", specifier = ">=1.0.1" },
-    { name = "protobuf", specifier = ">=5.26.1" },
+    { name = "protobuf", specifier = ">=5.29.5" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "semver", specifier = ">=3,<4" },
 ]


### PR DESCRIPTION
This should fix the build errors in the immediate, but I haven't done more research on what a better constraint should be for long-term reliability.