### PR TITLE
fix: Align TracingHook with spec

### DIFF
--- a/hooks/openfeature-hooks-opentelemetry/src/openfeature/contrib/hook/opentelemetry/__init__.py
+++ b/hooks/openfeature-hooks-opentelemetry/src/openfeature/contrib/hook/opentelemetry/__init__.py
@@ -70,6 +70,8 @@ class TracingHook(Hook):
             EventAttributes.RESULT_VALUE: json.dumps(hook_context.default_value),
         }
         if hook_context.provider_metadata:
-            attributes[EventAttributes.PROVIDER_NAME] = hook_context.provider_metadata.name
+            attributes[EventAttributes.PROVIDER_NAME] = (
+                hook_context.provider_metadata.name
+            )
         current_span = trace.get_current_span()
         current_span.record_exception(exception, attributes)

--- a/hooks/openfeature-hooks-opentelemetry/tests/test_otel.py
+++ b/hooks/openfeature-hooks-opentelemetry/tests/test_otel.py
@@ -12,8 +12,6 @@ from openfeature.hook import HookContext
 from openfeature.provider.metadata import Metadata
 
 
-
-
 @pytest.fixture
 def mock_get_current_span(monkeypatch):
     monkeypatch.setattr(trace, "get_current_span", Mock())
@@ -121,6 +119,7 @@ def test_error(mock_get_current_span):
 
     # Then
     mock_span.record_exception.assert_called_once_with(exception, attributes)
+
 
 def test_error_exclude_exceptions(mock_get_current_span):
     # Given


### PR DESCRIPTION
## Changes
This PR:
* Moves the span event creation logic to run in `finally_after` so it's run if the hook errors
* Adds an optional parameter `exclude_exception` to conditionally generate an exception on error (defaults to false to avoid breaking changes)
* Adds FLAG_KEY and RESULT_VALUE to the generated exception event

Done to align with the [spec](https://openfeature.dev/specification/appendix-d/#hook-lifecycle-implementation).

fixes #340 