### PR TITLE
fix: various custom operator conformance fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,3 @@
 [submodule "providers/openfeature-provider-flagd/openfeature/test-harness"]
 	path = providers/openfeature-provider-flagd/openfeature/test-harness
 	url = https://github.com/open-feature/flagd-testbed.git
-	branch = v3.5.0

--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/custom_ops.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/custom_ops.py
@@ -6,7 +6,7 @@ from openfeature.contrib.tools.flagd.core.targeting.custom_ops import (  # noqa:
     JsonPrimitive,
     ends_with,
     fractional,
-    parse_version,
+    normalize_version,
     sem_ver,
     starts_with,
     string_comp,

--- a/providers/openfeature-provider-flagd/tests/e2e/file/conftest.py
+++ b/providers/openfeature-provider-flagd/tests/e2e/file/conftest.py
@@ -15,7 +15,6 @@ feature_list = {
     "~contextEnrichment",
     "~deprecated",
     "~fractional-v1",
-    "~operator-errors",
 }
 
 

--- a/providers/openfeature-provider-flagd/tests/e2e/inprocess/conftest.py
+++ b/providers/openfeature-provider-flagd/tests/e2e/inprocess/conftest.py
@@ -9,7 +9,6 @@ feature_list = [
     "~unixsocket",
     "~deprecated",
     "~fractional-v1",
-    "~operator-errors",
 ]
 
 

--- a/providers/openfeature-provider-flagd/tests/e2e/rpc/conftest.py
+++ b/providers/openfeature-provider-flagd/tests/e2e/rpc/conftest.py
@@ -14,7 +14,9 @@ feature_list = [
     "~operator-errors",
     "~semver-v-prefix",
     "~fractional-single-entry",
+    "~semver-numeric-context",
 ]
+# TODO remove last 4 tags when adjusted flagd is released
 
 
 def pytest_collection_modifyitems(config, items):

--- a/providers/openfeature-provider-flagd/tests/e2e/rpc/conftest.py
+++ b/providers/openfeature-provider-flagd/tests/e2e/rpc/conftest.py
@@ -12,6 +12,8 @@ feature_list = [
     "~deprecated",
     "~fractional-v1",
     "~operator-errors",
+    "~semver-v-prefix",
+    "~fractional-single-entry",
 ]
 
 

--- a/providers/openfeature-provider-flagd/tests/e2e/rpc/conftest.py
+++ b/providers/openfeature-provider-flagd/tests/e2e/rpc/conftest.py
@@ -11,12 +11,7 @@ feature_list = [
     "~metadata",
     "~deprecated",
     "~fractional-v1",
-    "~operator-errors",
-    "~semver-v-prefix",
-    "~fractional-single-entry",
-    "~semver-numeric-context",
 ]
-# TODO remove last 4 tags when adjusted flagd is released
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tools/openfeature-flagd-core/pyproject.toml
+++ b/tools/openfeature-flagd-core/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "openfeature-flagd-api>=1.0.0,<2",
     "openfeature-sdk>=0.8.2",
     "mmh3>=5.0.0,<6.0.0",
-    "panzi-json-logic>=1.0.1",
+    "panzi-json-logic==1.0.1",
     "semver>=3,<4",
 ]
 requires-python = ">=3.10"

--- a/tools/openfeature-flagd-core/src/openfeature/contrib/tools/flagd/core/targeting/custom_ops.py
+++ b/tools/openfeature-flagd-core/src/openfeature/contrib/tools/flagd/core/targeting/custom_ops.py
@@ -176,4 +176,10 @@ def parse_version(arg: typing.Any) -> semver.Version:
     if version.startswith(("v", "V")):
         version = version[1:]
 
+    # Pad partial versions (e.g. "1" → "1.0.0", "1.2" → "1.2.0")
+    numeric_part = version.split("-")[0].split("+")[0]
+    dot_count = numeric_part.count(".")
+    if dot_count < 2:
+        version = version + ".0" * (2 - dot_count)
+
     return semver.Version.parse(version)

--- a/tools/openfeature-flagd-core/src/openfeature/contrib/tools/flagd/core/targeting/custom_ops.py
+++ b/tools/openfeature-flagd-core/src/openfeature/contrib/tools/flagd/core/targeting/custom_ops.py
@@ -125,10 +125,10 @@ def string_comp(
     arg1, arg2 = args
     if not isinstance(arg1, str):
         logger.debug(f"incorrect argument for first argument, expected string: {arg1}")
-        return False
+        return None
     if not isinstance(arg2, str):
         logger.debug(f"incorrect argument for second argument, expected string: {arg2}")
-        return False
+        return None
 
     return comparator(arg1, arg2)
 
@@ -144,8 +144,8 @@ def sem_ver(data: dict, *args: JsonLogicArg) -> bool | None:  # noqa: C901
     arg1, op, arg2 = args
 
     try:
-        v1 = parse_version(arg1)
-        v2 = parse_version(arg2)
+        v1 = normalize_version(arg1)
+        v2 = normalize_version(arg2)
     except ValueError as e:
         logger.exception(e)
         return None
@@ -171,7 +171,7 @@ def sem_ver(data: dict, *args: JsonLogicArg) -> bool | None:  # noqa: C901
         return None
 
 
-def parse_version(arg: typing.Any) -> semver.Version:
+def normalize_version(arg: typing.Any) -> semver.Version:
     version = str(arg)
     if version.startswith(("v", "V")):
         version = version[1:]

--- a/tools/openfeature-flagd-core/src/openfeature/contrib/tools/flagd/core/targeting/custom_ops.py
+++ b/tools/openfeature-flagd-core/src/openfeature/contrib/tools/flagd/core/targeting/custom_ops.py
@@ -180,6 +180,6 @@ def normalize_version(arg: typing.Any) -> semver.Version:
     numeric_part = version.split("-")[0].split("+")[0]
     dot_count = numeric_part.count(".")
     if dot_count < 2:
-        version = version + ".0" * (2 - dot_count)
+        version = numeric_part + ".0" * (2 - dot_count) + version[len(numeric_part) :]
 
     return semver.Version.parse(version)

--- a/tools/openfeature-flagd-core/tests/test_targeting.py
+++ b/tools/openfeature-flagd-core/tests/test_targeting.py
@@ -113,6 +113,9 @@ class TestSemVer:
     def test_v_prefix(self) -> None:
         assert sem_ver({}, "v2.0.0", "=", "2.0.0") is True
 
+    def test_partial_version(self) -> None:
+        assert sem_ver({}, "2", "=", "2.0.0") is True
+
     def test_invalid_version(self) -> None:
         result = sem_ver({}, "not-a-version", "=", "1.0.0")
         assert result is None

--- a/tools/openfeature-flagd-core/tests/test_targeting.py
+++ b/tools/openfeature-flagd-core/tests/test_targeting.py
@@ -117,8 +117,11 @@ class TestSemVer:
     def test_v_prefix(self) -> None:
         assert sem_ver({}, "v2.0.0", "=", "2.0.0") is True
 
-    def test_partial_version(self) -> None:
+    def test_partial_major_version(self) -> None:
         assert sem_ver({}, "2", "=", "2.0.0") is True
+
+    def test_partial_minor_version(self) -> None:
+        assert sem_ver({}, "v1.2", "=", "1.2.0") is True
 
     def test_invalid_version(self) -> None:
         result = sem_ver({}, "not-a-version", "=", "1.0.0")

--- a/tools/openfeature-flagd-core/tests/test_targeting.py
+++ b/tools/openfeature-flagd-core/tests/test_targeting.py
@@ -66,7 +66,7 @@ class TestStartsWith:
 
     def test_starts_with_non_string(self) -> None:
         result = starts_with({}, 123, "abc")
-        assert result is False
+        assert result is None
 
 
 class TestEndsWith:
@@ -77,6 +77,10 @@ class TestEndsWith:
     def test_ends_with_false(self) -> None:
         result = ends_with({}, "hello world", "hello")
         assert result is False
+
+    def test_ends_with_non_string(self) -> None:
+        result = ends_with({}, 123, "abc")
+        assert result is None
 
 
 class TestSemVer:

--- a/uv.lock
+++ b/uv.lock
@@ -1728,7 +1728,7 @@ requires-dist = [
     { name = "mmh3", specifier = ">=5.0.0,<6.0.0" },
     { name = "openfeature-flagd-api", editable = "tools/openfeature-flagd-api" },
     { name = "openfeature-sdk", specifier = ">=0.8.2" },
-    { name = "panzi-json-logic", specifier = ">=1.0.1" },
+    { name = "panzi-json-logic", specifier = "==1.0.1" },
     { name = "semver", specifier = ">=3,<4" },
 ]
 


### PR DESCRIPTION
* support partial versions in sem_ver
* return null instead of false for non-string inputs for starts_with and ends_with
* rename internal `parse_version` to `normalize_version`

⚠️ wait until flagd/RPC is updated to merge and remove the added exclude-feature tags in RPC

Fixes: https://github.com/open-feature/python-sdk-contrib/issues/379

---

Related:
* https://github.com/open-feature/flagd/pull/1950
* https://github.com/open-feature/java-sdk-contrib/pull/1778
* https://github.com/open-feature/js-sdk-contrib/pull/1519
* https://github.com/open-feature/dotnet-sdk-contrib/pull/635
* https://github.com/open-feature/go-sdk-contrib/pull/874