### PR TITLE
chore: stabilize transitive flagd deps

### DIFF
--- a/providers/openfeature-provider-flagd/pyproject.toml
+++ b/providers/openfeature-provider-flagd/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 keywords = []
 dependencies = [
   "openfeature-sdk>=0.8.2",
-  "openfeature-flagd-core",
+  "openfeature-flagd-core>=1.0.0,<2",
   "grpcio>=1.80.0",
   "protobuf>=6.30.0,<7.0.0",
   "pyyaml>=6.0.1",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -73,6 +73,7 @@
     },
     "tools/openfeature-flagd-api": {
       "package-name": "openfeature-flagd-api",
+      "release-as": "1.0.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default",
@@ -82,6 +83,7 @@
     },
     "tools/openfeature-flagd-core": {
       "package-name": "openfeature-flagd-core",
+      "release-as": "1.0.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default",

--- a/tools/openfeature-flagd-core/pyproject.toml
+++ b/tools/openfeature-flagd-core/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 keywords = []
 dependencies = [
-    "openfeature-flagd-api",
+    "openfeature-flagd-api>=1.0.0,<2",
     "openfeature-sdk>=0.8.2",
     "mmh3>=5.0.0,<6.0.0",
     "panzi-json-logic>=1.0.1",


### PR DESCRIPTION
This allows us to express transitive dep graphs that will allow us to handle breaking changes, as discussed [here](https://github.com/open-feature/python-sdk-contrib/pull/377#issuecomment-4269893277).