### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dev = [
 [tool.uv]
 required-version = ">=0.10.0"
 package = false
+constraint-dependencies = [
+  "mako>=1.3.12",
+]
 
 [tool.uv.sources]
 # hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ dev = [
 [tool.uv]
 required-version = ">=0.10.0"
 package = false
-constraint-dependencies = [
-  "mako>=1.3.12",
-]
 
 [tool.uv.sources]
 # hooks

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,6 @@ members = [
     "openfeature-provider-unleash",
     "openfeature-python-contrib",
 ]
-constraints = [{ name = "mako", specifier = ">=1.3.12" }]
 
 [[package]]
 name = "aioboto3"

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ members = [
     "openfeature-provider-unleash",
     "openfeature-python-contrib",
 ]
+constraints = [{ name = "mako", specifier = ">=1.3.12" }]
 
 [[package]]
 name = "aioboto3"
@@ -1202,14 +1203,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -1643,7 +1644,7 @@ wheels = [
 
 [[package]]
 name = "openfeature-flagd-api"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "tools/openfeature-flagd-api" }
 dependencies = [
     { name = "openfeature-sdk" },
@@ -1703,7 +1704,7 @@ dev = [
 
 [[package]]
 name = "openfeature-flagd-core"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "tools/openfeature-flagd-core" }
 dependencies = [
     { name = "mmh3" },
@@ -1854,7 +1855,7 @@ dev = [
 
 [[package]]
 name = "openfeature-provider-flagd"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "providers/openfeature-provider-flagd" }
 dependencies = [
     { name = "cachebox" },
@@ -1942,7 +1943,7 @@ dev = [
 
 [[package]]
 name = "openfeature-provider-ofrep"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "providers/openfeature-provider-ofrep" }
 dependencies = [
     { name = "openfeature-sdk" },


### PR DESCRIPTION
## Summary

- Bumped `mako` to `>=1.3.12` via a `constraint-dependencies` entry in the root `pyproject.toml` to resolve CVE-2026-44307 (high severity, path traversal via backslash URI on Windows in `TemplateLookup`)
- Regenerated `uv.lock` with `mako` 1.3.11 -> 1.3.12

Fixes Dependabot alert #30.