### PR TITLE
fix(flagd): log expected sync-stream recycles at debug, not warning

### DIFF
--- a/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
+++ b/providers/openfeature-provider-flagd/src/openfeature/contrib/provider/flagd/resolvers/process/connector/grpc_watcher.py
@@ -270,8 +270,8 @@ class GrpcWatcher(FlagStateConnector):
 
     def _handle_rpc_error(self, e: grpc.RpcError) -> bool:
         """Handle a gRPC RpcError. Returns True if the stream loop should stop."""
-        logger.warning(f"SyncFlags stream error, {e.code()=} {e.details()=}")
         if e.code().name in self.config.fatal_status_codes:
+            logger.error(f"SyncFlags stream fatal error, {e.code()=} {e.details()=}")
             self._is_fatal = True
             self.active = False
             self.emit_provider_error(
@@ -281,6 +281,10 @@ class GrpcWatcher(FlagStateConnector):
                 )
             )
             return True
+        # non-fatal errors just reconnect; real loss surfaces as a STALE event
+        logger.debug(
+            f"SyncFlags stream error, reconnecting, {e.code()=} {e.details()=}"
+        )
         return False
 
     def listen(self) -> None:


### PR DESCRIPTION
All our streams use a 10 minute deadline by default - for that reason, many stream "errors" represent expected behavior. The `stale -> error` transition is really what's a error - so this line should be DEBUG or we get massive logspam (this was unintentionally changed [here](https://github.com/open-feature/python-sdk-contrib/pull/362)).